### PR TITLE
add a workaround for survivor's miscalculation of ENDs in clever results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ that users understand how the changes affect the new version.
 -->
 version 1.3.0-dev
 ---------------------
-+ The gridss outputs are now included in survivor as well.
++ Fixed a bug which led to the removal of all BND, INS and INV events if DUPHOLD was enabled.
++ Updated SURVIVOR version to 1.0.7.
++ Added a workaround for a bug in survivor which caused the END of events detected by CLEVER to be calculated
+  incorrectly resulting in incorrect merging of events. 
++ ~~The gridss outputs are now included in survivor as well.~~
 + Smoove can now be disabled, by setting `SVcalling.runSmoove` to `false`.
 + Added Gridss as SV caller.
 + Fix order of input VCF files when removing missing and homozygous reference genotypes.

--- a/structural-variantcalling.wdl
+++ b/structural-variantcalling.wdl
@@ -56,7 +56,7 @@ workflow SVcalling {
             "manta": "quay.io/biocontainers/manta:1.4.0--py27_1",
             "picard":"quay.io/biocontainers/picard:2.23.2--0",
             "samtools": "quay.io/biocontainers/samtools:1.10--h9402c20_2",
-            "survivor": "quay.io/biocontainers/survivor:1.0.6--h6bb024c_0",
+            "survivor": "quay.io/biocontainers/survivor:1.0.7--hd03093a_2",
             "smoove": "quay.io/biocontainers/smoove:0.2.5--0",
             "duphold": "quay.io/biocontainers/duphold:0.2.1--h516909a_1",
             "gridss": "quay.io/biowdl/gridss:2.12.2"

--- a/structural-variantcalling.wdl
+++ b/structural-variantcalling.wdl
@@ -157,7 +157,7 @@ workflow SVcalling {
         (gridssSvTyped.vcf, "gridss")])
 
     scatter (svtype in svtypes) {
-         scatter (pair in vcfAndCaller) {
+        scatter (pair in vcfAndCaller) {
             String prefix = SVdir + pair.right + '/' + svtype
 
             call bcftools.View as getSVtype {
@@ -192,7 +192,7 @@ workflow SVcalling {
                     newId = "'${pair.right}\\_%CHROM\\_%POS\\_%END'"
             }
 
-            if (runDupHold) {
+            if (runDupHold && (svtype == "DEL" || svtype == "DUP")) {
                 call duphold.Duphold as annotateDH {
                     input:
                         dockerImage = dockerImages["duphold"],
@@ -226,7 +226,7 @@ workflow SVcalling {
             }
 
             File toBeMergedVcfs = select_first([removeMisHomRR.outputVcf, removeFpDupDel.outputVcf, setId.outputVcf])
-         }
+        }
 
         call survivor.Merge as survivor {
             input:

--- a/structural-variantcalling.wdl
+++ b/structural-variantcalling.wdl
@@ -293,6 +293,11 @@ task CleverWorkaround {
         String outputPath
     }
 
+    # This adds a meaningless field to the start of the INFO column if
+    # the first field if SVLEN. This is done to work around a bug in 
+    # survivor. Technically this isn't VCF spec compliant, since no new
+    # header is added for this INFO field. But since this is only used
+    # for survivor (which ignoes headers), that's not a problem.
     command {
         set -e
         mkdir -p $(dirname ~{outputPath})

--- a/structural-variantcalling.wdl
+++ b/structural-variantcalling.wdl
@@ -294,6 +294,8 @@ task CleverWorkaround {
     }
 
     command {
+        set -e
+        mkdir -p $(dirname ~{outputPath})
         sed 's/\tSVLEN=/\tWORKAROUND;SVLEN=/' ~{vcf} > ~{outputPath}
     }
 


### PR DESCRIPTION
### Checklist
- [x] Pull request details were added to CHANGELOG.md.
- [ ] Documentation was updated (if required).
- [ ] Workflow `parameter_meta` was added/updated (if required).
- [x] Submodule branches are on develop or a tagged commit.
